### PR TITLE
Fix compil for VS-2017

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ endfunction()
 # Must be called after find_package(CUDA) as the find_package call resets CUDA_NVCC_FLAGS
 macro(set_nvcc_flags)
     set(CUDA_PROPAGATE_HOST_FLAGS OFF)
+    set(CUDA_NVCC_FLAGS_DEBUG -D_DEBUG; )
 
     list(APPEND CUDA_NVCC_FLAGS -std=c++11;-arch=sm_30;)
     if (MSVC)

--- a/include/NodeNeuron.hpp
+++ b/include/NodeNeuron.hpp
@@ -37,7 +37,7 @@
 
 namespace N2D2 {
 
-class Synapse;
+struct Synapse;
 
 /**
  * Abstract neuron base class, which provides the minimum interface required for

--- a/src/CEnvironment.cpp
+++ b/src/CEnvironment.cpp
@@ -37,7 +37,8 @@ N2D2::CEnvironment::CEnvironment(Database& database,
       mStopStimulusTime(this, "StopStimulusTime", 0),
       mReadAerData(this, "ReadAerData", false),
       mStreamPath(this, "StreamPath", ""),
-      mNbSubStimuli(nbSubStimuli)
+      mNbSubStimuli(nbSubStimuli),
+      mNextEvent({true, true, false, true})
 {
    //ctor
     std::vector<size_t> dims({getSizeX(), getSizeY(), getNbChannels(), getBatchSize()});

--- a/src/Cell/Cell_CSpike.cpp
+++ b/src/Cell/Cell_CSpike.cpp
@@ -26,6 +26,7 @@
 N2D2::Cell_CSpike::Cell_CSpike(const DeepNet& deepNet, const std::string& name, 
                                unsigned int nbOutputs)
     : Cell(deepNet, name, nbOutputs)
+  , mInputs({true,true,false,true})
 {
     // ctor
 }

--- a/src/Cell/Cell_Frame.cpp
+++ b/src/Cell/Cell_Frame.cpp
@@ -29,6 +29,8 @@ N2D2::Cell_Frame<T>::Cell_Frame(const DeepNet& deepNet, const std::string& name,
                              const std::shared_ptr
                              <Activation>& activation)
     : Cell(deepNet, name, nbOutputs), Cell_Frame_Top(activation)
+  ,mInputs     ({true,true,false,true})
+  ,mDiffOutputs({true,true,false,true})
 {
     // ctor
 }

--- a/src/Cell/ConvCell_Frame.cpp
+++ b/src/Cell/ConvCell_Frame.cpp
@@ -67,6 +67,8 @@ N2D2::ConvCell_Frame<T>::ConvCell_Frame(const DeepNet& deepNet, const std::strin
       mBias(std::make_shared<Tensor<T> >()),
       mDiffBias({1, 1, getNbOutputs(), 1}),
       mConvDesc(subSampleDims, strideDims, paddingDims, dilationDims)
+      ,mSharedSynapses({true,true,false,true})
+      ,mDiffSharedSynapses({true,true,false,true})
 {
     // ctor
     if (kernelDims.size() != 2) {

--- a/src/Cell/DeconvCell_Frame.cpp
+++ b/src/Cell/DeconvCell_Frame.cpp
@@ -66,6 +66,8 @@ N2D2::DeconvCell_Frame<T>::DeconvCell_Frame(const DeepNet& deepNet, const std::s
       mDiffBias({1, 1, getNbOutputs(), 1}),
       mConvDesc(std::vector<unsigned int>({1, 1}), strideDims, paddingDims,
                 dilationDims)
+     ,mSharedSynapses({true,true,false,true})
+     ,mDiffSharedSynapses({true,true,false,true})
 {
     // ctor
     if (kernelDims.size() != 2) {

--- a/src/Cell/FcCell_Frame.cpp
+++ b/src/Cell/FcCell_Frame.cpp
@@ -55,6 +55,9 @@ N2D2::FcCell_Frame<T>::FcCell_Frame(const DeepNet& deepNet, const std::string& n
       // setParameter() or loadParameters().,
       mDropConnect(this, "DropConnect", 1.0),
       mLockRandom(false)
+     ,mSynapses({true,true,false,true})
+     ,mDiffSynapses({true,true,false,true})
+     ,mDropConnectMask({true,true,false,true})
 {
     // ctor
     mWeightsFiller = std::make_shared<NormalFiller<T> >(0.0, 0.05);

--- a/src/Cell/PoolCell_Frame.cpp
+++ b/src/Cell/PoolCell_Frame.cpp
@@ -63,6 +63,7 @@ N2D2::PoolCell_Frame<T>::PoolCell_Frame(const DeepNet& deepNet,
                 &poolDims[0],
                 &strideDims[0],
                 &paddingDims[0])
+    ,mArgMax({true,true,false,true})
 {
     // ctor
     assert(poolDims.size() <= POOL_KERNEL_MAX_DIMS);

--- a/src/Cell/ROIPoolingCell_Frame.cpp
+++ b/src/Cell/ROIPoolingCell_Frame.cpp
@@ -37,6 +37,7 @@ N2D2::ROIPoolingCell_Frame::ROIPoolingCell_Frame(const DeepNet& deepNet,
     : Cell(deepNet, name, nbOutputs),
       ROIPoolingCell(deepNet, name, sp, outputsWidth, outputsHeight, nbOutputs, pooling),
       Cell_Frame<Float_T>(deepNet, name, nbOutputs)
+    ,mArgMax({true,true,false,true})
 {
     // ctor
     mInputs.matchingDims({});

--- a/src/Cell/UnpoolCell_Frame.cpp
+++ b/src/Cell/UnpoolCell_Frame.cpp
@@ -44,6 +44,7 @@ N2D2::UnpoolCell_Frame::UnpoolCell_Frame(const DeepNet& deepNet, const std::stri
                 &poolDims[0],
                 &strideDims[0],
                 &paddingDims[0])
+    ,mArgMax({true,true,false,true})
 {
     // ctor
     assert(poolDims.size() <= POOL_KERNEL_MAX_DIMS);

--- a/tests/controler/class_Interface.cpp
+++ b/tests/controler/class_Interface.cpp
@@ -18,6 +18,8 @@
     knowledge of the CeCILL-C license and that you accept its terms.
 */
 
+#ifndef _WIN32
+
 #include "N2D2.hpp"
 
 #include "controler/Interface.hpp"
@@ -28,7 +30,7 @@ using namespace N2D2;
 
 TEST(Interface, Interface)
 {
-    const Interface<double> interface;
+    const Interface<double> interface = {true, true, false, true};
 
     ASSERT_EQUALS(interface.dimZ(), 0U);
     ASSERT_EQUALS(interface.dimB(), 0U);
@@ -46,7 +48,7 @@ TEST_DATASET(Interface,
              std::make_tuple(34U, 12U))
 {
     Tensor<int> A({dimX, dimY, 1, 1});
-    Interface<int> interface;
+    Interface<int> interface({true, true, false, true});
 
     ASSERT_EQUALS(interface.dimZ(), 0U);
     ASSERT_EQUALS(interface.dimB(), 0U);
@@ -76,7 +78,7 @@ TEST_DATASET(Interface,
              std::make_tuple(4U, 3U, 1U, 2U, 1U),
              std::make_tuple(4U, 3U, 3U, 5U, 10U))
 {
-    Interface<int> interface;
+    Interface<int> interface({true, true, false, true});
     Tensor<int> A1({dimX, dimY, dimZ1, dimB});
     Tensor<int> A2({dimX, dimY, dimZ2, dimB});
 
@@ -104,7 +106,7 @@ TEST_DATASET(Interface,
              std::make_tuple(2U, 2U, 1U, 2U, 2U, 1U, 1U, 1U),
              std::make_tuple(3U, 4U, 1U, 1U, 3U, 4U, 1U, 5U))
 {
-    Interface<int> interface;
+    Interface<int> interface({true, true, false, true});
     Tensor<int> A1({dimX1, dimY1, dimZ1, dimB1});
     Tensor<int> A2({dimX2, dimY2, dimZ2, dimB2});
 
@@ -131,7 +133,7 @@ TEST_DATASET(Interface,
 {
     Random::mtSeed(0);
 
-    Interface<int> interface;
+    Interface<int> interface({true, true, false, true});
     Tensor<int> A1({dimX, dimY, dimZ1, dimB});
     Tensor<int> A2({dimX, dimY, dimZ2, dimB});
 
@@ -193,7 +195,7 @@ TEST_DATASET(Interface,
 {
     Random::mtSeed(0);
 
-    Interface<int> interface;
+    Interface<int> interface({true, true, false, true});
     Tensor<int> A1({dimX, dimY, dimZ1, dimB}, 0);
     Tensor<int> A2({dimX, dimY, dimZ2, dimB}, 23);
 
@@ -239,7 +241,7 @@ TEST_DATASET(Interface,
              std::make_tuple(-10),
              std::make_tuple(125))
 {
-    Interface<int> interface;
+    Interface<int> interface({true, true, false, true});
     Tensor<int> A1({8, 8, 3, 4});
     Tensor<int> A2({8, 8, 5, 4});
 
@@ -267,7 +269,7 @@ TEST_DATASET(Interface,
 
 TEST(Interface, clear)
 {
-    Interface<int> interface;
+    Interface<int> interface({true, true, false, true});
     Tensor<int> A1({1, 2, 3, 4});
     Tensor<int> A2({1, 2, 5, 4});
 
@@ -283,3 +285,8 @@ TEST(Interface, clear)
 }
 
 RUN_TESTS()
+#else
+
+void main() {}
+
+#endif

--- a/tests/controler/class_Interface.cpp
+++ b/tests/controler/class_Interface.cpp
@@ -18,7 +18,7 @@
     knowledge of the CeCILL-C license and that you accept its terms.
 */
 
-#ifndef _WIN32
+#if not defined(_MSC_VER) || _MSC_VER<1910
 
 #include "N2D2.hpp"
 
@@ -285,8 +285,9 @@ TEST(Interface, clear)
 }
 
 RUN_TESTS()
-#else
 
-void main() {}
+#else // _MSC_VER
 
-#endif
+int main() { return -1; }
+
+#endif // _MSC_VER

--- a/tests/controler/class_Interface.cpp
+++ b/tests/controler/class_Interface.cpp
@@ -18,7 +18,7 @@
     knowledge of the CeCILL-C license and that you accept its terms.
 */
 
-#if not defined(_MSC_VER) || _MSC_VER<1910
+#if !defined(_MSC_VER) || _MSC_VER<1910
 
 #include "N2D2.hpp"
 


### PR DESCRIPTION
Here is a fix for compiling with Visual Studio 2017.
Actually there was several issues (**not all are solved**)

1/ the cmakelist must add _DEBUG to cuda library because otherwise the linker fails due to _HAS_ITERATOR_DEBUGGING incoherence (0 & 2).

2/ Actually there is a compiler bug preventing the automatic initialization of the class `Interface<T>` .
Hereafter I add a temporary trivial fix (using explicit instantiation), I've committed a bug report to microsoft.
https://developercommunity.visualstudio.com/content/problem/649717/compiler-issue-with-initializer-list-and-template.html

Normally it won't interfere with other compilers, but I can add `#if _WIN32 .... #endif`

3/ The file `tests/controler/class_Interface.cpp` crashes the compiler, **I could not fix it**, and I've simply bypassed it (commenting out its content). No bug report to MS were send.

Regards