### PR TITLE
Fix: popen failure make app crash + includes missing

### DIFF
--- a/include/RangeStats.hpp
+++ b/include/RangeStats.hpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
-#include <map>
+#include <unordered_map>
 
 namespace N2D2 {
 

--- a/src/RangeStats.cpp
+++ b/src/RangeStats.cpp
@@ -19,6 +19,7 @@
     knowledge of the CeCILL-C license and that you accept its terms.
 */
 
+#include <cassert>
 #include "RangeStats.hpp"
 #include "utils/Gnuplot.hpp"
 

--- a/src/utils/Gnuplot.cpp
+++ b/src/utils/Gnuplot.cpp
@@ -26,6 +26,9 @@ std::tuple<std::string, std::string, std::string> N2D2::Gnuplot::mDefaultOutput
     = std::make_tuple<std::string, std::string, std::string>(
         "png", "size 800,600 enhanced large", "png");
 
+#include <cstring>
+#include <cerrno>
+
 N2D2::Gnuplot::Gnuplot(const std::string& fileName) : mSubPipe(false)
 {
     if (mMasterCmdPipe == NULL) {
@@ -36,8 +39,10 @@ N2D2::Gnuplot::Gnuplot(const std::string& fileName) : mSubPipe(false)
 #endif
 
         if (mCmdPipe == NULL)
-            throw std::runtime_error(
-                "Couldn't open connection to gnuplot (is it in the PATH?)");
+        {
+            std::string msg = "Couldn't open connection to gnuplot (is it in the PATH?): " + std::string(std::strerror(errno));
+            throw std::runtime_error(msg);
+        }
     } else {
         mSubPipe = true;
         mCmdPipe = mMasterCmdPipe;

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -19,6 +19,8 @@
     knowledge of the CeCILL-C license and that you accept its terms.
 */
 
+#include <cstring>
+#include <cerrno>
 #include <cmath>
 #include "utils/Utils.hpp"
 
@@ -491,13 +493,13 @@ bool N2D2::Utils::createDirectories(const std::string& dirName)
 
 std::string N2D2::Utils::exec(const std::string& cmd) {
 #ifdef WIN32
-    std::shared_ptr<FILE> pipe(_popen(cmd.c_str(), "r"), _pclose);
+    std::unique_ptr<FILE, decltype(&_pclose)> pipe(_popen(cmd.c_str(), "r"), _pclose);
 #else
-    std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
 #endif
 
     if (!pipe)
-        throw std::runtime_error("Utils::exec(): popen() failed!");
+        throw std::runtime_error("Utils::exec('" + cmd + "'): popen() failed: " + std::strerror(errno));
 
     std::string result;
     std::array<char, 128> buffer;


### PR DESCRIPTION
## Popen error

### Encountered issue

When I tryied to generate a ResNet-50, the application n2d2 crashed with a segfault.

### Cause

After debug, I found that this crash was made by the function [`N2D2::Utils::exec`](https://github.com/CEA-LIST/N2D2/blob/d66da81cdc7c1dce6ac9d29ebf586d5a4fa16d74/src/utils/Utils.cpp#L492) :
-  The function `popen` returned a `NULL` pointer and triggers a `runtime_error`
-  This exception call the destructor of the `pipe` object (which is a `shared_pointer`)
-  The [cpp specification for `shared_pointer`](https://en.cppreference.com/w/cpp/memory/shared_ptr/~shared_ptr) says that `Unlike std::unique_ptr, the deleter of std::shared_ptr is invoked even if the managed pointer is null.`
-  So, the function `pclose` (registered as deleter) is called with a `NULL` pointer and make the app crash

### Fix

To fix this Issue, I replaced the `shared_ptr` by a `unique_ptr` which is better in that case because :
-  The pointer used here is not "shared" but "unique" because created and deleted in the same function
-  The [cpp specification for `unique_ptr`](https://en.cppreference.com/w/cpp/memory/unique_ptr/~unique_ptr) says that `If get() == nullptr there are no effects. Otherwise, the owned object is destroyed via get_deleter()(get()).`

## Includes missing

### Encountered issue

On Centos7, I couldn't manage to build the `n2d2` target because of some includes missing.

### Cause

In the file [`include/RangeStats.hpp`](https://github.com/CEA-LIST/N2D2/blob/master/include/RangeStats.hpp), some `unordered_map` are declared but only the `map` header is included.

In the file [`src/RangeStats.hpp`](https://github.com/CEA-LIST/N2D2/blob/master/src/RangeStats.cpp), the function `assert` is called without the inclusion of `cassert`.

### Fix

Just added the missing includes in the files and remove useless ones.

## Popen failed ??!!??

In the function [`N2D2::Utils::exec`](https://github.com/CEA-LIST/N2D2/blob/d66da81cdc7c1dce6ac9d29ebf586d5a4fa16d74/src/utils/Utils.cpp#L492) and at the construction of a [`N2D2::Gnuplot`](https://github.com/CEA-LIST/N2D2/blob/d66da81cdc7c1dce6ac9d29ebf586d5a4fa16d74/src/utils/Gnuplot.cpp#L29) object, the function `popen` is called.

At some points, this function can fail and, in my case, it was because I didn't have enough memory on my environment (cf. #47).

Then I decided to improve error messages with `strerror` and `errno` in both cases.
